### PR TITLE
Changed Indent description

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -11,7 +11,7 @@ Most sections are broken up into two parts:
 
 **Icon Legend**:
 
-`·` Space, `⇥` Tab, `↵` Enter/Return
+`·` Space, `⇥` Indent, `↵` Enter/Return
 
 <!-- ---------------------------------------------------------------------- -->
 


### PR DESCRIPTION
# Description

In the intro of the Style Guide the indent character had been described as a Tab.  This is in conflict with the style guide itself which specifies that indents should be two spaces rather than a tab.

## Fixes 

The description was changed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

None.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
