### PR TITLE
Emailer file redirect and index order resolved

### DIFF
--- a/.env
+++ b/.env
@@ -37,3 +37,7 @@ DATABASE_URL="mysql://db_user:db_password@127.0.0.1:3306/db_name?serverVersion=5
 # Gmail SHOULD NOT be used on production, use it in development only.
 # MAILER_DSN=gmail://USERNAME:PASSWORD@default
 ###< symfony/google-mailer ###
+
+###> custom variables ###
+HOSTNAME='localhost:8000'
+###< custom variables ###

--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,3 +1,6 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
     form_themes: ['bootstrap_4_horizontal_layout.html.twig']
+
+    globals:
+        hostname: '%env(HOSTNAME)%'

--- a/templates/mailer.html.twig
+++ b/templates/mailer.html.twig
@@ -12,8 +12,12 @@
     </div>
     <div class="w3-panel">
       <ul>
-        {% for row in announcements %}
-          <li><a href="#{{ row.id }}">{{ row.subject }}</a></li>
+        {% for category in categories %}
+          {% for row in announcements %}
+            {% if row.category.name == category.name %}
+              <li><a href="#{{ row.id }}">{{ row.subject }}</a></li>
+            {% endif %}
+          {% endfor %}
         {% endfor %}
       </ul>
       {% for category in categories %}
@@ -27,7 +31,7 @@
               <h3>{{ row.subject }}</h3>
               <p class="author">{{ row.author }}</p>
               <div class="w3-card"><p>{{ row.text }}</p></div>
-              {% if row.filename is defined and row.filename is not null %}<a href="{{ vich_uploader_asset(row, 'announcementFile',  'App\\Entity\\Announcement') }}" class="w3-button w3-ripple w3-border myOnbutton" target="_blank" rel="noopener noreferrer">View File</a> {{ row.filename[0:-27] ~ row.filename[-4:] }}{% endif %}
+              {% if row.filename is defined and row.filename is not null %}<a href="https://{{ hostname }}{{ vich_uploader_asset(row, 'announcementFile',  'App\\Entity\\Announcement') }}" class="w3-button w3-ripple w3-border myOnbutton" target="_blank" rel="noopener noreferrer">View File</a> {{ row.filename[0:-27] ~ row.filename[-4:] }}{% endif %}
               <a href="#top"><p class="w3-tiny w3-serif">Top</p></a>
             {% endif %}
           {% endfor %}


### PR DESCRIPTION
# Description

Simple bug fixes. 

## Fixes 

Files sent in emailers were not redirecting properly. Adding a hostname to the .env file(s) resolves the issue. This will be needed in production.

The "Table of Contents" was also in exact order from newest to oldest announcements, whereas the lower communicator overview was sorted by category, then newest to oldest. Simply adding another check during the contents table creation resolved this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Practical tests for emailer. All old tests pass perfectly.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
